### PR TITLE
add working conda env yml file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,18 @@
+name: dipole
+channels:
+  - pytorch
+  - open3d-admin
+  - conda-forge
+dependencies:
+  - cudatoolkit=10.2
+  - matplotlib
+  - open3d=0.13.0
+  - pip
+  - pot=0.7.0
+  - pytorch=1.9.0
+  - requests
+  - scikit-learn
+  - tqdm
+  - pip:
+    - gudhi==3.4.0
+    - umap-learn==0.5.1


### PR DESCRIPTION
Adds a conda environment file with which I was able to run the `RUNME.py` example script. It may be that some version restrictions could be relaxed, but I had to definitely freeze the gudhi version to `3.4.0` and pytorch `1.4.0` didn't work for me. Also, I originally tried on Ubuntu 16.04, but `open3d` doesn't support Ubuntu older than 18.04