### PR TITLE
Use giotto-ph instead of GUDHI to compute flag persistence generators

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,5 +14,6 @@ dependencies:
   - scikit-learn
   - tqdm
   - pip:
+    - giotto-ph>=0.2.0
     - gudhi==3.4.0
     - umap-learn==0.5.1

--- a/pers.py
+++ b/pers.py
@@ -24,7 +24,8 @@ class RipsPersistenceDistance(nn.Module):
         # Compute persistence from distance matrix.
         idx = ripser_parallel(input.detach().numpy(),
                               metric="precomputed",
-                              maxdim=max(self.hom_dims))["gens"]
+                              maxdim=max(self.hom_dims)
+                              return_generators=True)["gens"]
         dgms = []
         for hom_dim in self.hom_dims:
             if hom_dim == 0:

--- a/pers.py
+++ b/pers.py
@@ -1,5 +1,6 @@
 # Collection of pytorch modules for persistence related calculations
 
+from gph import ripser_parallel
 import gudhi as gd
 from gudhi.wasserstein import wasserstein_distance
 import torch
@@ -21,10 +22,9 @@ class RipsPersistenceDistance(nn.Module):
 
     def forward(self, input):
         # Compute persistence from distance matrix.
-        rips = gd.RipsComplex(distance_matrix=input.detach().numpy())
-        st = rips.create_simplex_tree(max_dimension=max(self.hom_dims) + 1)
-        st.persistence()
-        idx = st.flag_persistence_generators()
+        idx = ripser_parallel(input.detach().numpy(),
+                              metric="precomputed",
+                              maxdim=max(self.hom_dims))["gens"]
         dgms = []
         for hom_dim in self.hom_dims:
             if hom_dim == 0:

--- a/pers.py
+++ b/pers.py
@@ -24,7 +24,7 @@ class RipsPersistenceDistance(nn.Module):
         # Compute persistence from distance matrix.
         idx = ripser_parallel(input.detach().numpy(),
                               metric="precomputed",
-                              maxdim=max(self.hom_dims)
+                              maxdim=max(self.hom_dims),
                               return_generators=True)["gens"]
         dgms = []
         for hom_dim in self.hom_dims:


### PR DESCRIPTION
Being based on `ripser` (with additional performance improvements and parallelisation capabilities), `giotto-ph`'s persistent homology backend is faster than GUDHI's.